### PR TITLE
Change timeout.Timeout into an interface.

### DIFF
--- a/server/activefiles.go
+++ b/server/activefiles.go
@@ -36,7 +36,7 @@ type ActiveFile struct {
 	currentUpload     *currentUpload
 	readLocker        sync.Locker
 	dataAvailableCond *sync.Cond
-	timeout           *timeout.Timeout
+	timeout           timeout.Timeout
 	userKey           string
 	state             activeFileState
 
@@ -88,7 +88,7 @@ func (self *ActiveFileManager) PrepareUpload(fileExtension string, userKey strin
 
 			activeFile.dataAvailableCond = sync.NewCond(activeFile.readLocker)
 
-			activeFile.timeout = timeout.NewTimeout(10*time.Second, func() {
+			activeFile.timeout = timeout.New(10*time.Second, func() {
 				func() {
 					activeFile.Lock()
 

--- a/server/timeout/timeout.go
+++ b/server/timeout/timeout.go
@@ -2,16 +2,23 @@ package timeout
 
 import "time"
 
+type Timeout interface {
+	Reset() bool
+	Cancel() bool
+}
+
 type responseChanType chan bool
 type controlChanType chan responseChanType
 
-type Timeout struct {
+type timeout struct {
 	resetChan  controlChanType
 	cancelChan controlChanType
 }
 
-func NewTimeout(duration time.Duration, timeoutFunc func()) *Timeout {
-	timeout := &Timeout{
+// New creates a Timeout, which calls timeoutFunc after duration.
+// It can be reset or cancelled.
+func New(duration time.Duration, timeoutFunc func()) Timeout {
+	timeout := &timeout{
 		resetChan:  make(controlChanType),
 		cancelChan: make(controlChanType),
 	}
@@ -44,7 +51,7 @@ func NewTimeout(duration time.Duration, timeoutFunc func()) *Timeout {
 	return timeout
 }
 
-func (self *Timeout) Reset() bool {
+func (self *timeout) Reset() bool {
 	responseChan := make(responseChanType)
 
 	self.resetChan <- responseChan
@@ -52,7 +59,7 @@ func (self *Timeout) Reset() bool {
 	return <-responseChan
 }
 
-func (self *Timeout) Cancel() bool {
+func (self *timeout) Cancel() bool {
 	responseChan := make(responseChanType)
 
 	self.cancelChan <- responseChan


### PR DESCRIPTION
- Since there's only one New\* func in timeout package, it's more idiomatic to call it timeout.New() rather than the redundant timeout.NewTimeout(). See [Go style guide](https://code.google.com/p/go-wiki/wiki/CodeReviewComments#Package_Names).
- Changing Timeout struct to be unexported makes the API clearer; timeout.New() is the only way to create it. No longer possible to create timeout.Timeout{} struct which would be invalid.
