### PR TITLE
Display more common formats inline in browser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-InstantShare
-============
+Instant Share
+=============
 
-Instantly share images/files on the web.
+Instantly share images, videos, and other files on the web.

--- a/server/contenttype.go
+++ b/server/contenttype.go
@@ -1,18 +1,19 @@
 package main
 
-import "path/filepath"
+import (
+	"mime"
+	"path/filepath"
+)
 
 func ContentTypeFromFileName(fileName string) string {
-	switch filepath.Ext(fileName) {
-	case ".png":
-		return "image/png"
-	case ".jpg", ".jpeg":
-		return "image/jpeg"
-	case ".mov":
-		// TODO: Handle this correctly. "video/quicktime" is correct, but I'm temporarily using "video/mp4" for testing in Chrome.
-		//return "video/quicktime"
+	ext := filepath.Ext(fileName)
+	if ext == ".mov" {
+		// "video/quicktime" is correct, but temporarily using "video/mp4" because it plays in Chrome.
 		return "video/mp4"
-	default:
+	}
+	contentType := mime.TypeByExtension(ext)
+	if contentType == "" {
 		return "application/octet-stream"
 	}
+	return contentType
 }


### PR DESCRIPTION
Use mime package to detect most common file formats and set their content-type appropriately, rather than using "application/octet-stream" for all unsupported formats. Resolves #17.

Update README with app name (as is currently set in app tooltip) and updated description.