### PR TITLE
Add CORS support.

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -38,6 +38,10 @@ func getWebHandler(activeFileManager *ActiveFileManager, fileStore FileStore) ht
 		method := req.Method
 		path := urlPathToArray(req.URL.Path)
 
+		res.Header().Set("Access-Control-Allow-Origin", "*")
+		res.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		res.Header().Set("Access-Control-Allow-Methods", "GET, PUT, OPTIONS")
+
 		switch {
 		case len(path) == 1:
 			if method == "GET" {
@@ -55,7 +59,10 @@ func getWebHandler(activeFileManager *ActiveFileManager, fileStore FileStore) ht
 			} else if method == "PUT" {
 				// uploading a file
 				handlePutFile(res, req, path[0], activeFileManager)
+			} else if method == "OPTIONS" {
+				return
 			} else {
+				res.Header().Set("Allow", "GET, PUT, OPTIONS")
 				http.Error(res, "Method Not Allowed", http.StatusMethodNotAllowed)
 			}
 		case len(path) == 2 && path[0] == "api" && path[1] == "getfilename" && method == "GET":


### PR DESCRIPTION
This way, frontend clients are treated the same way as backend clients
in their ability to operate.

Set Allow header when status is Method Not Allowed.

According to section 10.4.6 of http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html:

> The method specified in the Request-Line is not allowed for the resource identified by the Request-URI. **The response MUST include an Allow header containing a list of valid methods for the requested resource.**