### PR TITLE
client: Ensure response status code is 200 OK.

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"image"
 	"image/png"
 	"io/ioutil"
@@ -103,6 +104,13 @@ func instantShareHandler() {
 		return
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		err := fmt.Errorf("did not get acceptable status code: %v body: %q", resp.Status, body)
+		trayhost.Notification{Title: "Upload Failed", Body: err.Error()}.Display()
+		log.Println(err)
+		return
+	}
 	filename, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		trayhost.Notification{Title: "Upload Failed", Body: err.Error()}.Display()


### PR DESCRIPTION
It's expected to be 200 OK on a successful response from the InstantShare server.

If it's another value, it might indicate that the server failed to prepare an upload, or we might be talking to a non-InstantShare server due to configuration (e.g., DNS issues).

Fixes #28.